### PR TITLE
Publish puppet module

### DIFF
--- a/.github/workflows/publish-puppet-module.yaml
+++ b/.github/workflows/publish-puppet-module.yaml
@@ -1,0 +1,23 @@
+name: publish-puppet-module
+
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest tag
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF:10}
+    - name: Clone repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ steps.vars.outputs.tag }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v2.4.0
+      env:
+       FORGE_API_KEY: ${{ secrets.PUPPET_FORGE_TOKEN }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Release 
 
+### 1.0.0
+
 **Features**
+Initial release, all current features documented in the README
 
 **Bugfixes**
 
 **Known Issues**
+DHCP, IPSET and TLS/SSL not yet implemented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Release 
 
-### 1.0.0
+### 0.1.0
 
 **Features**
 Initial release, all current features documented in the README

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![validate-puppet-module Actions Status](https://github.com/shoddyguard/Puppet-Adguard/workflows/validate-puppet-module/badge.svg?branch=main)](https://github.com/shoddyguard/Puppet-Adguard/actions)
+[![validate-puppet-module Actions Status](https://github.com/shoddyguard/Puppet-Adguard/workflows/validate-puppet-module/badge.svg?branch=main)](https://github.com/shoddyguard/Puppet-Adguard/actions)[![publish-puppet-module Actions Status](https://github.com/shoddyguard/Puppet-Adguard/workflows/publish-puppet-module/badge.svg)](https://github.com/shoddyguard/Puppet-Adguard/actions)
 # Puppet-Adguard
 Puppet module for installing and managing AdGuard Home
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![validate-puppet-module Actions Status](https://github.com/shoddyguard/puppet_adguard/workflows/validate-puppet-module/badge.svg?branch=main)](https://github.com/shoddyguard/Puppet-Adguard/actions)
+[![validate-puppet-module Actions Status](https://github.com/shoddyguard/Puppet-Adguard/workflows/validate-puppet-module/badge.svg?branch=main)](https://github.com/shoddyguard/Puppet-Adguard/actions)
 # Puppet-Adguard
 Puppet module for installing and managing AdGuard Home
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "shoddyguard-adguard",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "author": "Steve Brown",
   "summary": "Manages AdGuard Home",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR should add the bits necessary for publishing the module to Puppet Forge.
This should take care of #6 